### PR TITLE
Add more sources for sueddeutsche.de

### DIFF
--- a/src/sites.js
+++ b/src/sites.js
@@ -214,7 +214,7 @@ export default {
     },
     source: 'genios.de',
     sourceParams: {
-      dbShortcut: 'SZ'
+      dbShortcut: 'SZ, SZDE, SZPT, SZPW, SZRE, SZW'
     }
   },
   'sz-magazin.sueddeutsche.de': {


### PR DESCRIPTION
Fixes #92 (without Süddeutsche Zeitung Magazin, as this is a separate entry)

The following wiso sources are added for search queries: sueddeutsche.de, Süddeutsche Zeitung PRIMETIME, Süddeutsche Zeitung Plan W, Süddeutsche Zeitung - Regionalteile und Süddeutsche Zeitung WISSEN