### PR TITLE
Fix alternative Süddeutsche Zeitung sources

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -216,7 +216,7 @@ const sites: Sites = {
     },
     source: 'genios.de',
     sourceParams: {
-      dbShortcut: 'SZ, SZDE, SZPT, SZPW, SZRE, SZW'
+      dbShortcut: 'SZ,SZDE,SZPT,SZPW,SZRE,SZW'
     }
   },
   'sz-magazin.sueddeutsche.de': {


### PR DESCRIPTION
The spaces between the different SZ sources prevent them from being searched, related to #92 and #95