### PR TITLE
Add Spiegel Plus shortcut for www.spiegel.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -98,7 +98,7 @@ const sites: Sites = {
     dateRange: [7, 1], // search from 7 days before to one day after given date
     source: 'genios.de',
     sourceParams: {
-      dbShortcut: 'SPII,KULS,SPIE,SPON,SSPE,UNIS,LISP,SPBE'
+      dbShortcut: 'SPPL,SPII,KULS,SPIE,SPON,SSPE,UNIS,LISP,SPBE'
     }
   },
   'plus.tagesspiegel.de': {


### PR DESCRIPTION
Genios.de hat als shortcut für Spiegel Plus `SPPL` unter dem bspw. der Artikel aus #79 publiziert wurde. Die Änderung sorgt dafür, dass er gefunden wird.