### PR TITLE
Remove SPON for spiegel.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -107,7 +107,7 @@ const sites: Sites = {
     dateRange: [7, 1], // search from 7 days before to one day after given date
     source: 'genios.de',
     sourceParams: {
-      dbShortcut: 'SPPL,SPII,KULS,SPIE,SPON,SSPE,UNIS,LISP,SPBE'
+      dbShortcut: 'SPPL,SPII,KULS,SPIE,SSPE,UNIS,LISP,SPBE'
     }
   },
   'plus.tagesspiegel.de': {


### PR DESCRIPTION
Mein Eindruck ist, dass ein Großteil der false positives auf spiegel.de von der Quelle "Spiegel Online (SPON)" verursacht werden. Gleichzeitig scheint es sich dabei auch nur um frei erhältliche Artikel ohne Paywall zu handeln, die für das Addon also ohne Bedeutung sind. Wesentlich scheinen mir auf spiegel.de SPPL (Spiegel Plus) und SPIE (Der Spiegel) zu sein.