### PR TITLE
Add Stadtbibliothek Oranienburg

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -121,6 +121,12 @@ const geniosDefaultData: PartialProviderData[] = [
     name: 'Stadtbibliothek Oberhausen',
     web: 'https://www.oberhausen.de/stadtbibliothek',
     domain: 'bib-oberhausen.genios.de'
+  },
+  {
+   id: 'oranienburg.de',
+   name: 'Stadtbibliothek Oranienburg',
+   web: 'https://stadtbibliothekoranienburg.bibliotheca-open.de/',
+   domain: 'bib-oranienburg.genios.de'
   }
 ]
 


### PR DESCRIPTION
Closes #165

This has been tested by building and installing the extension locally, using credentials from the institution and using the Zeit Paywall article from the settings page of the extension.