### PR TITLE
Update sites.ts

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -271,7 +271,7 @@ const sites: Sites = {
   },
   'www.handelsblatt.com': {
     selectors: {
-      query: '.vhb-article-area--read > p',
+      query: '.vhb-article--introduction',
       // date: "span[itemprop='datePublished']",
       paywall: '.c-paywall',
       main: '.vhb-article-area--read'


### PR DESCRIPTION
Selects the teaser instead of the first paragraph
The first paragraph is sometimes faulty because it includes a location mark that isn’t in the print article