### PR TITLE
WIP: Add munzinger.de Login for Münchner Stadtbibliothek

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install
 npm start
 ```
 
+In order to build an installable extension, run `./dist.sh`.
+
 ## Extension overview
 
 The extension has four different entry points:

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -629,6 +629,34 @@ const providers: Providers = {
     ],
     permissions: ['https://www.voebb.de/*']
   },
+  'muenchner-stadtbibliothek.de': {
+    name: 'Münchner Stadtbibliothek',
+    web: 'https://www.muenchner-stadtbibliothek.de/',
+    params: {
+      'www.munzinger.de': {
+        portalId: '52372'
+      }
+    },
+    login: [
+      [
+        { click: 'input[name="CLOGIN"]', optional: true, skipToNext: true }
+      ],
+      [
+        { message: 'Bibliothekskonto wird eingeloggt...' },
+        { fill: { selector: 'input[name="L#AUSW"]', providerKey: 'muenchner-stadtbibliothek.de.options.username' } },
+        { fill: { selector: 'input[name="LPASSW"]', providerKey: 'muenchner-stadtbibliothek.de.options.password' } },
+        { click: 'input[name="LLOGIN"]' }
+      ],
+      [
+        { click: 'input[name="CLOGIN"]', optional: true }
+      ]
+    ],
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' }
+    ],
+    permissions: ['https://ssl.muenchen.de/*']
+  },
   'stadtbibliothek.leipzig.de': {
     name: 'Leipziger Städtische Bibliotheken',
     web: 'https://stadtbibliothek.leipzig.de/',


### PR DESCRIPTION
How can I test it?

Munich City Library also has access to "Süddeutsche Zeitung" via Munzinger directly. Other news can be accessed via PressReader.com.

Fixes #110 