### PR TITLE
Updated abendblatt.de, waz.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -387,7 +387,7 @@ const sites: Sites = {
   },
   'www.abendblatt.de': {
     selectors: {
-      query: "[itemprop='headline']",
+      query: "h2",
       main: '.article__body',
       date: 'time',
       paywall: '#paywall-container'
@@ -399,7 +399,7 @@ const sites: Sites = {
   },
   'www.waz.de': {
     selectors: {
-      query: '[itemprop="headline"]',
+      query: 'h2',
       date: 'time',
       paywall: '#paywall-container',
       main: '.article__header__intro'


### PR DESCRIPTION
Die Selektoren für die Headline funktionierten nicht mehr