### PR TITLE
Updated link for BSB München

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "BibBot",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "description": "Vereinfacht die Suche nach Artikeln in der Bibliothek",
   "icons": {
     "48": "icons/bibbot-48.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bibbot",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bibbot",
-      "version": "0.26.8",
+      "version": "0.26.9",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.20.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bibbot",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "description": "BibBot removes paywalls of German media sites",
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -732,7 +732,7 @@ const providers: Providers = {
     web: 'https://www.bsb-muenchen.de/',
     params: {
       'genios.de': {
-        domain: 'www-1wiso-2net-1de-1001394go0ffe.emedia1.bsb-muenchen.de'
+        domain: 'www-1wiso-2net-1de-101vwuxwl0445.emedia1.bsb-muenchen.de'
       }
     },
     login: [


### PR DESCRIPTION
The extension didn't work for BSB on my end (error 404). I logged into my BSB account and retrieved the link for 'wiso', which was different from the one used in the extension. After updating the link in the extension configuration, everything worked as expected.