### PR TITLE
Probleme mit WiWo+ Artikeln

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -432,7 +432,7 @@ const sites: Sites = {
       }
     ],
     selectors: {
-      query: makeQueryFunc('.c-leadtext'),
+      query: makeQueryFunc('.c-headline'),
       main: '.o-article__content',
       paywall: '.isArticle .isPremium',
       date: 'time'


### PR DESCRIPTION
Fixes #196

M.E. muss die Abfragebedingung in src/sites.ts:432 geändert werden von
query: makeQueryFunc('.c-leadtext'),
zu
query: makeQueryFunc('.c-headline'),