### PR TITLE
Basic support for mobile

### DIFF
--- a/src/sourcebot.ts
+++ b/src/sourcebot.ts
@@ -9,6 +9,7 @@ import { ArticleInfo, Source, Provider, SiteSourceParams, Message } from './type
 
 enum PHASE {
   LOGIN = 'login',
+  SWITCH_TO_DESKTOP_VERSION = 'switchToDesktopVersion',
   SEARCH = 'search',
 }
 
@@ -184,6 +185,8 @@ class SourceBot {
     const actionList = this.getActionList()
     if (this.step > actionList.length - 1) {
       if (this.phase === PHASE.LOGIN) {
+        this.phase = PHASE.SWITCH_TO_DESKTOP_VERSION
+      } else if (this.phase === PHASE.SWITCH_TO_DESKTOP_VERSION) {
         this.phase = PHASE.SEARCH
       }
       this.step = 0

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -10,6 +10,7 @@ const sources: Sources = {
       // adding an empty ?portalid= parameter works in these cases
       portalId: ''
     },
+    switchToDesktopVersion: [],
     login: [
       [
         { click: '.gdprcookie-buttons button', optional: true },
@@ -35,13 +36,24 @@ const sources: Sources = {
     defaultParams: {
       domain: 'www.genios.de'
     },
+    switchToDesktopVersion: [
+      [
+        { click: '#f_c6' }
+      ]
+    ],
     login: [
       [
         { fill: { selector: '#bibLoginLayer_number', key: 'options.username' } },
         { fill: { selector: '#bibLoginLayer_password', key: 'options.password' } },
         { click: '#bibLoginLayer_terms' },
         { click: '#bibLoginLayer_gdpr' },
-        { click: '#bibLoginLayer_c0' }
+        { click: '#bibLoginLayer_c0' },
+        // Mobile
+        { fill: { selector: '#f_p_number', key: 'options.username' } },
+        { fill: { selector: '#f_p_password', key: 'options.password' } },
+        { click: '#f_p_terms' },
+        { click: '#f_p_gdpr' },
+        { click: '#f_p_c2' }
       ]
     ],
     search: [
@@ -65,6 +77,7 @@ const sources: Sources = {
     start: '{source.startUrl.raw}',
     defaultParams: {
     },
+    switchToDesktopVersion: [],
     login: [],
     search: [
       [

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,7 @@ export type Source = {
   start: string
   defaultParams: DefaultSourceParams
   login: Actions[]
+  switchToDesktopVersion: Actions[]
   search: Actions[]
 }
 


### PR DESCRIPTION
The extension didn't work for me on Firefox (Nightly) on Android.
I figured this was because the extension loads the mobile view of genios which has a different HTML structure.

This PR adds actions for the mobile login screen and adds a phase to click the button that switches to the desktop version of the page.

Possibly fixes (or at least improves) #151 