### PR TITLE
Fix Zeit.de selector for title

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -152,7 +152,7 @@ const sites: Sites = {
       }
     ],
     selectors: {
-      query: makeQueryFunc(['.article__item .paragraph:nth-child(2)', '.article__item .paragraph', '.article__item .summary']),
+      query: makeQueryFunc(['.article-heading__title', '.article__item .paragraph', '.article__item .summary']),
       edition: '.metadata__source',
       date: '.metadata__source.encoded-date, time',
       paywall: '#paywall, .gate',


### PR DESCRIPTION
Zeit.de has changed the layout for the article title. The title for the article is now in `.article-heading__title`. As the current selector doesn't match, I replaced the first one to select the article title now correctly.