### PR TITLE
WIP: Stadtbibliothek Karlsruhe hinzugefügt

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -911,6 +911,23 @@ const providers: Providers = {
       'https://advance-lexis-com.eu1.proxy.openathens.net/*',
       'https://katalog.dortmund.de/*'
     ]
+  },
+  'www.karlsruhe.de': {
+    name: 'Stadtbibliothek Karlsruhe',
+    web: 'https://stadtbibliothek.karlsruhe.de',
+    params: {
+      'www.munzinger.de': {
+        portalId: '51802'
+      }
+    },
+    defaultSource: 'www.munzinger.de',
+    login: [],
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' }
+    ],
+    permissions: [
+    ]
   }
 }
 


### PR DESCRIPTION
Fügt die Stadtbibliothek Karlsruhe hinzu. Leider war dies in meinem Tests noch nicht besonders nützlich, da Karlsruhe kein Genios, sondern Munzinger abonniert hat.

Das scheint momentan noch nicht ganz fertig zu sein - zumindest scheint da aktuell immer nur nach dem Spiegel gesucht zu werden.