### PR TITLE
Fix Permissions for Uni Bonn

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
     "https://*.bsb-muenchen.de/*",
     "https://go.openathens.net/*",
     "https://katalog.dortmund.de/*",
-    "https://advance-lexis-com.eu1.proxy.openathens.net/*"
+    "https://advance-lexis-com.eu1.proxy.openathens.net/*",
+    "https://*.bonn.idm.oclc.org/*"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
permissions already existed in providers.ts but were missing in manifest. 
add https://*.bonn.idm.oclc.org/* to optional_permissions in manifest, fixes #325