### PR TITLE
New Genios: Support date filter

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -51,7 +51,7 @@ const sources: Sources = {
     search: [
       [
         { message: 'Artikel wird gesucht...' },
-        { url: '{source.scheme.raw}{source.domain.raw}/searchResult/Alle%20Quellen?requestText={query}' }
+        { url: '{source.scheme.raw}{source.domain.raw}/searchResult/Alle%20Quellen?requestText={query}&date=from_{dateStart}&date=to_{dateEnd}' }
       ],
       [
         { message: 'Artikel wird aufgerufen...' },


### PR DESCRIPTION
The support for the new genios removed the date filter as well as the dbshortcut filter.  This re-adds the former.

Cf. #364 on discussion of the format change and the different format of the new dbshortcut filter (not addressed in this PR).