### PR TITLE
Fix Leipziger Städtische Bibliotheken

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -74,6 +74,12 @@ const geniosDefaultData: PartialProviderData[] = [
     web: 'https://www.stadtbibliothek-jena.de/',
     domain: 'bib-jena.genios.de'
   },
+  {
+    id: 'stadtbibliothek.leipzig.de',
+    name: 'Leipziger Städtische Bibliotheken',
+    web: 'https://stadtbibliothek.leipzig.de/',
+    domain: 'stadtbib-leipzig.genios.de'
+  },
   // {
   //   id: 'stabi.ludwigsburg.de',
   //   name: 'Stadtbibliothek Ludwigsburg',
@@ -689,38 +695,6 @@ const providers: Providers = {
   ...oclcProviders,
   ...hanProviders,
   ...astecProviders,
-  'stadtbibliothek.leipzig.de': {
-    name: 'Leipziger Städtische Bibliotheken',
-    web: 'https://stadtbibliothek.leipzig.de/',
-    params: {
-      'genios.de': {
-        domain: 'stadtbib-leipzig.genios.de'
-      }
-    },
-    login: [
-      [
-        { message: 'Bibliothekskonto wird eingeloggt...' },
-        { url: 'https://stadtbibliothek.leipzig.de/online-angebote/login-online-angebote' }
-      ],
-      [
-        { fill: { selector: '#user', providerKey: 'stadtbibliothek.leipzig.de.options.username' } },
-        { fill: { selector: '#pass', providerKey: 'stadtbibliothek.leipzig.de.options.password' } },
-        { click: '#permalogin' },
-        { click: '.powermail_submit' }
-      ],
-      [
-        { url: 'https://sso.stadtbibliothek.leipzig.de/service/genios' }
-      ]
-    ],
-    options: [
-      { id: 'username', display: 'Nutzername:', type: 'text' },
-      { id: 'password', display: 'Passwort:', type: 'password' }
-    ],
-    permissions: [
-      'https://stadtbibliothek.leipzig.de/*',
-      'https://*.stadtbibliothek.leipzig.de/*'
-    ]
-  },
   'www.duesseldorf.de': {
     name: 'Stadtbibliothek Düsseldorf',
     web: 'https://www.duesseldorf.de/stadtbuechereien/onlinebibliothek.html',


### PR DESCRIPTION
The recent Genios UI fix did not fix the support for Leipzig. It appears that the extension first opens the website of the library of Leipzig, logs in there and then redirects to Genios. The redirect was wrong before, that has been fixed by the update. The extension now loads the new Genios UI eventually. However, no login information is entered there. 

I am not sure why the extension first opens this other website, rather than opening the Genios site directly. I only tried out the extension a couple of weeks ago. Maybe this is some sort of legacy behavior with the old Genios site (or even before that?). If I convert the declaration to the one used by Jena, Essen and others, the Genios interface opens right away and login succeeds as expected.

Not sure if this is the correct fix though, so very much open for feedback. Thank you for this project!