### PR TITLE
Add Münchner Stadtbibliothek

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "https://katalog.dortmund.de/*",
     "https://advance-lexis-com.eu1.proxy.openathens.net/*",
     "https://*.bonn.idm.oclc.org/*",
-    "https://online-service2.nuernberg.de/*"
+    "https://online-service2.nuernberg.de/*",
+    "https://ssl.muenchen.de/*"
   ],
   "background": {
     "scripts": [

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -1,6 +1,6 @@
 import { ArticleInfo, ExtractorInterface, FormattedDateRange, RawArticleInfo, Site } from './types.js'
 
-const QUOTES = /["„].*["„]/
+const QUOTES = /["„]/
 
 class Extractor implements ExtractorInterface {
   site: Site
@@ -159,7 +159,7 @@ class Extractor implements ExtractorInterface {
     // remove some special chars
     q = q.replace(/[!:?;'/()]/g, ' ').replace(/(((?<!\d)[,.])|([,.](?!\d)))/g, ' ').replace(/ {1,}/g, ' ')
     // remove non-leading/trailing quotes
-    q = q.split(QUOTES).map(s => s.trim()).filter(s => s.split(' ').length > 1).map(s => `"${s}"`).join(' ')
+    q = q.split(QUOTES).map(s => s.trim()).filter(s => s.split(' ').length > 1).map(s => `${s}`).join(' ')
     articleInfo.query = q
     return {
       query: articleInfo.query,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -714,6 +714,37 @@ const providers: Providers = {
   ...oclcProviders,
   ...hanProviders,
   ...astecProviders,
+  'muenchner-stadtbibliothek.de': {
+    name: 'Münchner Stadtbibliothek',
+    web: 'https://www.muenchner-stadtbibliothek.de/',
+    defaultSource: 'www.munzinger.de',
+    params: {
+      'www.munzinger.de': {
+        portalId: '52372'
+      }
+    },
+    login: [
+      [
+        { message: 'GDPR akzeptieren und Redirect zur Bibliotheksseite...' },
+        { click: '.gdprcookie-buttons button', optional: true },
+        { click: 'img[src="/grafiken/button-weiter.gif"]' }
+      ],
+      [
+        { message: 'Bibliothekskonto wird eingeloggt...' },
+        { fill: { selector: 'input[name="L#AUSW"]', providerKey: 'muenchner-stadtbibliothek.de.options.username' } },
+        { fill: { selector: 'input[name="LPASSW"]', providerKey: 'muenchner-stadtbibliothek.de.options.password' } },
+        { click: 'input[name="LLOGIN"]' }
+      ],
+      [
+        { click: 'input[name="CLOGIN"]', optional: true }
+      ]
+    ],
+    options: [
+      { id: 'username', display: 'Nutzername:', type: 'text' },
+      { id: 'password', display: 'Passwort:', type: 'password' }
+    ],
+    permissions: ['https://ssl.muenchen.de/*', 'https://www.munzinger.de/*']
+  },
   'www.duesseldorf.de': {
     name: 'Stadtbibliothek Düsseldorf',
     web: 'https://www.duesseldorf.de/stadtbuechereien/onlinebibliothek.html',

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -21,7 +21,7 @@ const sources: Sources = {
     search: [
       [
         { message: 'Artikel wird gesucht...' },
-        { url: 'https://{source.domain.raw}/search/query?template=%2Fpublikationen%2Fspiegel%2Fresult.jsp&query.id=query-spiegel&query.key=gQynwrIS&query.commit=yes&query.scope=spiegel&query.index-order=personen&query.facets=yes&facet.path=%2Fspiegel&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel={query}&query.Ausgabe={edition}&query.Ressort=&query.Signatur=&query.Person=&query.K%C3%B6rperschaft=&query.Ort=&query.Text={overline}' }
+        { url: 'https://{source.domain.raw}/search/query?template=%2Fpublikationen%2Fsz%2Fresult.jsp&query.id=query-sz&query.key=yP49gv3q&query.commit=yes&query.scope=sz&query.index-order=personen&query.facets=yes&facet.path=%2Fsz&facet.activate=yes&hitlist.highlight=yes&hitlist.sort=-field%3Aisort&query.Titel=&query.Datum=&query.Ressort=&query.Thema=&query.Person=&query.Institution=&query.Text={query}' }
       ],
       [
         { click: '.gdprcookie-buttons button', optional: true },


### PR DESCRIPTION
This PR supersedes #184.

I am not sure about the change from hardcoded Spiegel to SZ in the munzinger search URL. Do you have any hint about how to implement this better? With a separate `Sources`?

The change in the extractor is done to really remove the quotes from the query parameter. This is done, because special chars are also removed and thus an exact search for the query does not reveal any results anymore.

I tested my changes successfully with the following URLs
- https://www.sueddeutsche.de/projekte/artikel/politik/lkw-unfaelle-beim-abbiegen-im-toten-winkel-e744638/?reduced=true
- https://www.sueddeutsche.de/kultur/wladimir-sorokin-gastbeitrag-putin-1.5536912?reduced=true
- https://www.sueddeutsche.de/muenchen/muenchen-kita-foerderformel-florian-kraus-kinderbetreuung-1.6320367?reduced=true
