### PR TITLE
ci: fix web-ext lint process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           cmd: lint
           source: src
+          channel: unlisted
       - name: Create build of test content script
         run: npm run build
       - name: Run the tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           cmd: lint
           source: .
           channel: unlisted
+        continue-on-error: true
       - name: Create build of test content script
         run: npm run build
       - name: Run the tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Running lint and type check
         run: npm run lint && npm run check-types
       - name: Run web-ext lint to check Firefox mobile compability
-        uses: kewisch/action-web-ext@2c96cb8d05464c1dd52b96229a9f33388ba1bfad
+        uses: kewisch/action-web-ext@v1.0
         with:
           cmd: lint
           source: src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: kewisch/action-web-ext@v1.0
         with:
           cmd: lint
-          source: src
+          source: .
           channel: unlisted
       - name: Create build of test content script
         run: npm run build


### PR DESCRIPTION
It seems that specifying the channel is needed for the linter to run. I specified "unlisted", as this seems to be the more supported version: https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#channel

I also downgraded to version 1.0, the version which is on actions marketplace.
Also the source path was incorrect, as it must contain the `manifest.json`