### PR TITLE
Extend selector for genios.de to check if user is logged in

### DIFF
--- a/src/sources.ts
+++ b/src/sources.ts
@@ -30,7 +30,7 @@ const sources: Sources = {
     ]
   },
   'genios.de': {
-    loggedIn: '#header__login__buttons > button:nth-child(4)',
+    loggedIn: ':is(#header__login[auth=true], #header__login__buttons > button:nth-child(4))',
     start: '{source.scheme.raw}{source.domain.raw}/',
     defaultParams: {
       domain: 'www.genios.de',


### PR DESCRIPTION
The previous code tested that there is a bookmark icon visible, which is not the case for all genios.de instances (e.g. bib-oranienburg.genios.de). The new selector checks the old condition or that the "auth" parameter is set to "true".