### PR TITLE
Fix freiepresse.de

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -959,16 +959,16 @@ const sites: Sites = {
       {
         url: 'https://www.freiepresse.de/chemnitz/einwohnerversammlungen-in-chemnitz-kuenftig-wieder-vor-ort-artikel13507031',
         selectors: {
-          query: '"im Wasserschloss Klaffenbach Tiere Musik und Schokolade"'
+          query: '"wird es künftig wieder Einwohnerversammlungen in den Stadtteilen geben Das hat der neu"'
         }
       }
     ],
     selectors: {
       query: makeQueryFunc('.article__shorttext', true),
       headline: '.article__headline',
-      paywall: '#upscore-paywall-placeholder',
-      date: '.article-date',
-      main: '.article__shorttext'
+      paywall: '.default-paywall',
+      date: '.article__etag div',
+      main: '#artikel-content'
     },
     waitOnLoad: true,
     source: 'genios.de',


### PR DESCRIPTION
The recent change in e32470461c44f5bab54bb8de3c3cbc5285fc8275 was incomplete. This appears to work (tested with [this article](https://www.freiepresse.de/zwickau/zwickau/so-diskutiert-das-netz-ueber-die-vw-krise-den-ueberheblichen-mitarbeitern-goenne-ich-das-sogar-artikel13517014)) and passes the tests.

Resolves #461