### PR TITLE
fix(escapeJsString): unbork code broken by prettier - fixes #514

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-
 const ident = (x) => x
 
 function interpolate(
@@ -25,7 +24,8 @@ function interpolate(
 }
 
 const escapeJsString = (str) => {
-  return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+  // prettier-ignore
+  return str.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')
 }
 
 export { escapeJsString, interpolate }


### PR DESCRIPTION
This revert's a prettier change which breaks the JS encoding of sources like c't. They get messed up to something like c\`t which Genios dutyfully
acknowledges with a HTTP 400 Bad request.

More see https://github.com/stefanw/bibbot/issues/514

Closes #514