### PR TITLE
Paywall der BZ wurde nicht mehr erkannt wg veränderter id

### DIFF
--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1334,7 +1334,7 @@ const sites: Sites = {
       query: makeQueryFunc('.artikelPreview'),
       headline: 'h1',
       date: 'p.article__header__info-area__txt a[href*="/archiv"]',
-      paywall: '#regWalli',
+      paywall: '#articleWall',
       main: '.artikelPreview',
     },
     source: 'genios.de',


### PR DESCRIPTION
Habe die ID der Paywall angepasst, sodass diese wieder korrekt erkannt werden kann. Beispielartikel: https://www.badische-zeitung.de/freiburgs-surfwelle-rollt-und-ermoeglicht-wellenreiten-inmitten-der-stadt

So sieht das betreffende Element aus:
```html
<article id="articleWall" class="article-site | mb-1000">
    <div>
        <div class="freemium | bg-neutral-200 shadow">
            <div rel="registerForm" id="hauptformular" class="registerForm">
                <p class="txt-center">
                    <img class="badge" src="/~images/badge/abo-bzo.svg" alt="BZ-Abo" title="BZ-Abo" style="width:3.4em;display:inline-block;">
                    -Artikel - exklusiv im Abo
                </p>
                <p class="txt-center | pb-900"><strong>Mit BZ-Digital Basis direkt weiterlesen:</strong></p>
                            <div class="freemium-box | bg-neutral-100 shadow" id="aboWallBox01">
                    <h3 class="fb-title-bz | pall-900">
                        <p id="trigger1" class="accordion-trigger | flex ai-c | lh-1 | fw-b">
                            <span>3 Monate</span>
                            <span class="txt-right | ml-auto">3 € / Monat<br><small class="fw-400 fw-r">danach 15,90 € / Monat</small></span>
                        </p>
                    </h3>
                    <div id="panel1" role="region" class="accordion-content | fs-400" aria-labelledby="trigger1" aria-hidden="false">
                        <div>
                            <ul class="icon-list-dye | ptb-400" role="list">
                                <li class="check accent3 | pb-400">Alle Artikel frei auf badische-zeitung.de</li>
                                <li class="check accent3 | pb-400">News-App BZ-Smart</li>
                                <li class="check accent3 | pb-400">Freizeit-App BZ-Lieblingsplätze</li>
                            </ul>
                            <a onclick="" href="https://www.badische-zeitung.de/abo/shortcheckout?productid=1259&amp;aboaktid=DXPP_VA_B_2M&amp;werbeaktion=DXPPI2M&amp;cn=sale-wall-bzabo" title="Jetzt abonnieren" target="_blank" class="orderBtn btn | bg-accent3-400 fc-neutral-100 | mt-600 txt-center">
                                Jetzt abonnieren
                            </a>
                            <p class="txt-center | pb-400"><small><strong>nach 3 Monaten jederzeit kündbar</strong></small></p>
                            <p class="txt-center | pb-900"><small>Abonnent/in der gedruckten Badischen Zeitung? <a href="/registrierung" class="txt-link">Hier</a> kostenlosen Digital-Zugang freischalten.</small></p>
                        </div>
                    </div>
                </div>
                        </div>
        </div>
    </div>
    <p class="wall-login | txt-right | fs-300 | mt-900">Bereits Digital-Abonnent:in?<br> 
        <script src="https://www.badische-zeitung.de/~js/core/sso/1.0.0.js"></script>
        <meinebz-login-button label="Anmelden" mode="popup" client_id="1a606130-837b-4c1d-b89a-cd5cc39668b2" state="ahsdiufi">
        </meinebz-login-button>
    </p>
</article>
```